### PR TITLE
Add retry functionality

### DIFF
--- a/lib/api.ex
+++ b/lib/api.ex
@@ -106,8 +106,8 @@ defmodule TheTVDB.API do
   end
 
   defp opts(opts) do
-    defaults = [requires_auth: true, scope: :global]
-    opts = Keyword.merge(defaults, opts)
+    opts = Keyword.put_new(opts, :requires_auth, true)
+    opts = Keyword.put_new(opts, :scope, :global)
 
     if opts[:requires_auth] do
       Keyword.put_new_lazy(opts, :token, fn ->

--- a/lib/thetvdb.ex
+++ b/lib/thetvdb.ex
@@ -37,6 +37,28 @@ defmodule TheTVDB do
       # Fetch user authentication for jamesDean
       TheTVDB.User.info("jamesDean")
       # => {:ok, %TheTVDB.User{username: "jamesDean", ...}}
+
+
+  ## Automatic retries
+
+  In the event of a service outage, requests will be retried using an
+  exponential backoff strategy. The formula for the delay (in milliseconds)
+  between requests is as follows:
+
+      (2 ** num_attempts) * backoff_multiplier
+
+  ## Configuration
+
+  The parameters below are able to be configured by the user:
+  - max_attempts - The maximum number of attempts for a single request (default: 5)
+  - backoff_multiplier - See "Automatic retries" section above (default: 300)
+
+  To modify the default configuration, add the following to your config:
+
+      config :thetvdb,
+        max_attempts: 10,
+        backoff_multiplier: 500
+
   """
 
   import TheTVDB.API.Utils, only: [unwrap_or_raise: 1]


### PR DESCRIPTION
Using exponential backoff below, allow the user to configure the following:
  - Max attempts (default: 5)
  - Backoff multiplier (default: 300)

`2 ** num_attemps * backoff_multiplier`