### PR TITLE
Don't return streams

### DIFF
--- a/lib/series.ex
+++ b/lib/series.ex
@@ -140,10 +140,8 @@ defmodule TheTVDB.Series do
 
   @doc """
   Get all episodes for a given series.
-
-  An `Enumerable` of `TheTVDB.Series.BasicEpisode` is returned.
   """
-  @spec episodes(integer) :: {:ok, Enumerable.t} | {:error, term}
+  @spec episodes(integer) :: {:ok, [BasicEpisode.t]} | {:error, term}
   def episodes(series_id) do
     case TheTVDB.API.get_iter("/series/#{series_id}/episodes") do
       {:ok, data} ->
@@ -156,7 +154,7 @@ defmodule TheTVDB.Series do
   @doc """
   See `episodes/1`.
   """
-  @spec episodes!(integer) :: Enumerable.t
+  @spec episodes!(integer) :: [BasicEpisode.t]
   def episodes!(series_id), do: episodes(series_id) |> unwrap_or_raise
 
   @doc """

--- a/lib/series.ex
+++ b/lib/series.ex
@@ -145,10 +145,12 @@ defmodule TheTVDB.Series do
   """
   @spec episodes(integer) :: {:ok, Enumerable.t} | {:error, term}
   def episodes(series_id) do
-    stream = TheTVDB.API.get_stream("/series/#{series_id}/episodes")
-             |> Stream.map(&BasicEpisode.from_json/1)
-
-    {:ok, stream}
+    case TheTVDB.API.get_iter("/series/#{series_id}/episodes") do
+      {:ok, data} ->
+        {:ok, Enum.map(data, &BasicEpisode.from_json/1)}
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 
   @doc """

--- a/lib/user.ex
+++ b/lib/user.ex
@@ -115,10 +115,12 @@ defmodule TheTVDB.User do
   """
   @spec ratings(username) :: {:ok, [Rating.t]}
   def ratings(username \\ nil) do
-    stream = TheTVDB.API.get_stream("/user/ratings", scope: scope(username))
-             |> Stream.map(&Rating.from_json/1)
-
-    {:ok, stream}
+    case TheTVDB.API.get_iter("/user/ratings", scope: scope(username)) do
+      {:ok, data} ->
+        {:ok, Enum.map(data, &Rating.from_json/1)}
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 
   @doc """


### PR DESCRIPTION
Currently, any endpoint that returns a stream may throw if a timeout occurs while processing the stream. This is because we assume if the first request (`page=1`) was successful, the subsequent request(s) won't timeout.

Instead, of returning a stream, just build up results into a list and return `{:error, reason}` if any one of the requests fails.

This update should only require a minor version bump. The documentation defines the return value to be an `Enumerable` for all streaming endpoints (which a list is).